### PR TITLE
cn can be in uppercase

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -36,7 +36,7 @@ Puppet::Type.
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
-          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/).captures
+          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/i).captures
         when /^olcDbDirectory: /
           directory = line.split(' ')[1]
         when /^olcRootDN: /
@@ -98,11 +98,11 @@ Puppet::Type.
           end
         end
       end
-      if backend == 'monitor' and !suffix
-        suffix = 'cn=monitor'
+      if backend.match(/monitor/i) and !suffix
+        suffix = "cn=#{backend}"
       end
-      if backend == 'config' and !suffix
-        suffix = 'cn=config'
+      if backend.match(/config/i) and !suffix
+        suffix = "cn=#{backend}"
       end
       new(
         :ensure          => :present,


### PR DESCRIPTION
On my host :

slapcat -b cn=config -a "(|(olcDatabase=monitor)(olcDatabase={0}config)(&(objectClass=olcDatabaseConfig)(|(objectClass=olcBdbConfig)(objectClass=olcHdbConfig)(objectClass=olcMdbConfig)(objectClass=olcMonitorConfig)(objectClass=olcRelayConfig))))" |grep -e ^olcDatabase
olcDatabase: {0}config
olcDatabase: {1}mdb
olcDatabase: {2}Monitor